### PR TITLE
install gPodder via Git instead of package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN echo "**** Installing gPodder ****" && \
     git clone https://github.com/gpodder/gpodder.git && \
     cd gpodder && \
     git checkout $GPODDER_TAG && \
-    make install && \
     echo "GPODDER_DOWNLOAD_DIR=/downloads" >> ~/.pam_environment
 
 RUN apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM lsiobase/guacgui
 LABEL maintainer="xthursdayx"
 
 ENV APPNAME="gPodder" 
+ENV GPODDER_TAG="3.10.16"
 
 RUN \
-echo "**** Installing dep packages ****" && \
-apt-get update && \
-apt-get install -y \
+    echo "**** Installing dep packages ****" && \
+    apt-get update && \
+    apt-get install -y \
     ca-certificates \
     dbus \
     default-dbus-session-bus \
@@ -29,20 +30,27 @@ apt-get install -y \
     python3-mygpoclient \
     python3-podcastparser \
     python3-simplejson \
-    wget && \
-echo "**** Installing gPodder ****" && \
-apt-get install -y gpodder && \
-echo "GPODDER_DOWNLOAD_DIR=/downloads" >> ~/.pam_environment && \
-apt-get clean && \
-rm -rf \
+    wget \
+    git \
+    intltool
+
+RUN echo "**** Installing gPodder ****" && \
+    git clone https://github.com/gpodder/gpodder.git && \
+    cd gpodder && \
+    git checkout $GPODDER_TAG && \
+    make install && \
+    echo "GPODDER_DOWNLOAD_DIR=/downloads" >> ~/.pam_environment
+
+RUN apt-get clean && \
+    rm -rf \
     /tmp/* \
     /var/lib/apt/lists/* \
     /var/tmp/*
-    
+
 ENV LANG en_US.UTF-8 \
     LANGUAGE en_US.UTF-8 \
     LC_ALL en_US.UTF-8
-	
+
 COPY root/ /
 
 VOLUME /config

--- a/root/etc/services.d/gPodder/run
+++ b/root/etc/services.d/gPodder/run
@@ -11,4 +11,4 @@ s6-setuidgid abc
 s6-env DISPLAY=:1 HOME=/config GPODDER_DOWNLOAD_DIR=/downloads LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # Execute gPodder
-/usr/bin/gpodder
+dbus-run-session /gpodder/bin/gpodder


### PR DESCRIPTION
## Summary

This PR:
* upgrades the image from gPodder `3.10.1` (~2 years old) to `3.10.16`
* installs gPodder via `git clone` instead of relying on Ubuntu's package for it
  * ... which conveniently allows us to control the version of gPodder being built into the image, via `GPODDER_TAG` 
  * ... but is a bit riskier w/r/t security, since we're trusting the code that happens to be tagged on GitHub at build time
* breaks the image's `RUN` statement into multiple parts (per [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)), for faster dev rebuilds
* includes a change to the gPodder service definition, since I was getting dbus error messages otherwise
  * this is not my area of expertise, so feel free to call it a dirty hack, won't bother me 🙂 

## Alternatives considered

I thought about nudging the OS forward to pick up newer gPodder versions without changing the install method itself (groovy [has the latest](https://packages.ubuntu.com/groovy/gpodder)), but given that this image inherits from guacgui it wasn't clear how much effort that would've required.