### PR TITLE
add normalize-audio package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN \
     libgtk-3-dev \
     locales \
     locales-all \
+    normalize-audio \
     python3 \
     python3-cairo \
     python3-dbus \


### PR DESCRIPTION
The `normalize-package` package will allow the [normalizeaudio](https://gpodder.github.io/docs/extensions/normalizeaudio.html) extension to be enabled.

Otherwise, without the package, it would throw an error
![Screen Shot 2020-11-05 at 12 43 05 AM](https://user-images.githubusercontent.com/16546412/98211865-f1f82f80-1eff-11eb-9874-a0cbb1208d62.png)
