### PR TITLE
Changed source for package wqy-zenhei from testing to community

### DIFF
--- a/dark/Dockerfile
+++ b/dark/Dockerfile
@@ -54,10 +54,10 @@ RUN \
     breeze-icons \
     font-roboto \
     gtk-murrine-engine \
-    gnome-themes-extra && \
- apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    materia-dark \
+    gnome-themes-extra \
     wqy-zenhei && \
+ apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    materia-dark && \
  echo "**** install PyPI deps ****" && \
  pip3 install --no-cache-dir \
     mygpoclient==1.9 \

--- a/light/Dockerfile
+++ b/light/Dockerfile
@@ -47,7 +47,7 @@ RUN \
     ttf-freefont \
     libxfont \
     font-noto && \
- apk add wqy-zenhei --update-cache --repository https://nl.alpinelinux.org/alpine/edge/testing && \
+ apk add wqy-zenhei --update-cache --repository https://nl.alpinelinux.org/alpine/edge/community && \
  echo "**** install PyPI deps ****" && \
  pip3 install --no-cache-dir \
     mygpoclient==1.9 \


### PR DESCRIPTION
I was unable to build because the package wqy-zenhei was not found, and per [this post](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15509) this package has been moved to the community repository. This is how I got the images to build, but I'm not sure if this is really the appropriate solution to the problem.